### PR TITLE
Fix multiple paths

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   language: system
   files: \.php$
   fail_fast: true
-  args: [ fix, --allow-risky=yes, --no-interaction ]
+  args: [ fix, --allow-risky=yes, --config=.php-cs-fixer.dist.php, --no-interaction ]
   stages: [ pre-commit, pre-merge-commit, pre-push, manual ]
 
 - id: phpstan


### PR DESCRIPTION
When multiple paths are passed, PHP CS Fixer requires the `--config` parameter.

https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/4279